### PR TITLE
fix: merge map

### DIFF
--- a/steit/src/types/map/map.rs
+++ b/steit/src/types/map/map.rs
@@ -184,6 +184,9 @@ impl<K: MapKey, V: State> Deserialize for Map<K, V> {
     fn merge(&mut self, reader: &mut Reader<impl io::Read>) -> io::Result<()> {
         while !reader.eof()? {
             let field_number = u32::deserialize(reader)?;
+
+            let (field_number, _) = wire_fmt::parse_tag(field_number)?;
+
             wire_fmt::validate_field_number(field_number)?;
             K::try_from_field_number(field_number)?;
 


### PR DESCRIPTION
- `field_number` in this context is included tag and field_number so we need to first extract two of them before validate else they will failed in case of field_number is larger than `2^26`